### PR TITLE
Corrected regex which failed when given more than one scss file

### DIFF
--- a/builder/src/components/Renderer.ts
+++ b/builder/src/components/Renderer.ts
@@ -20,7 +20,7 @@ export const render = (
     });
 
     htmlContent = htmlContent.replace(
-        /<link rel="stylesheet" href="(?<file>.*\.scss)"\/>/,
+        /<link rel="stylesheet" href="(?<file>.*?\.scss)"\/>/g,
         (match, file) => {
             const targetFile = path.join(sourceDirectory, file);
 


### PR DESCRIPTION
The wildcard selector was set to greedy mode, which meant that when looking for `.*\.scss` it will consume all characters up until the last `\.scss`

Also the replacement was set to non-global, so it exited after the first replacement